### PR TITLE
Basic docstrings for public python classes and functions.

### DIFF
--- a/src/lephare/filter.py
+++ b/src/lephare/filter.py
@@ -12,12 +12,21 @@ filter_config_keys = ["FILTER_REP", "FILTER_LIST", "TRANS_TYPE", "FILTER_CALIB",
 
 
 class Filter(Runner):
+    """Build the filter files based on config
+
+    Parameters
+    ----------
+    config_file : `string`
+    """
+
     def __init__(self, config_file=None, config_keymap=None):
         super().__init__(filter_config_keys, config_file, config_keymap)
 
     def run(self, **kwargs):
-        # update keymap and verbosity based on call arguments
-        # this is only when the code is called from python session
+        """Update keymap and verbosity based on call arguments.
+
+        This is only when the code is called from python session.
+        """
         self.verbose = kwargs.pop("verbose", self.verbose)
         for k, v in kwargs.items():
             if k.upper() in self.keymap:

--- a/src/lephare/filterSvc.py
+++ b/src/lephare/filterSvc.py
@@ -16,8 +16,25 @@ SVO_URL = "http://svo2.cab.inta-csic.es/theory/fps"
 
 
 class FilterSvc:
+    """Filter service for retrieving filters from various sources.
+
+    This class defines a number of methods for loading and manipulating filters.
+    """
+
     @classmethod
     def from_yaml(cls, yaml_file):
+        """Load filter from a yaml file
+
+        Parameters
+        ----------
+        yaml_file : `str`
+            Path to yaml file
+
+        Returns
+        -------
+        flt_array :  list of `lephare.flt`
+            Array of wavelengths in Angstrom and filter transmissivity.
+        """
         config = yaml.load(open(yaml_file), Loader=yaml.BaseLoader)["filters"]  # noqa: SIM115
         if "calib" in config:
             default_calib = config["calib"]
@@ -40,6 +57,18 @@ class FilterSvc:
 
     @classmethod
     def from_config(cls, config_file):
+        """Load filter from a .para config file
+
+        Parameters
+        ----------
+        config_file : `str`
+            Path to config file
+
+        Returns
+        -------
+        flt_array : list of `lephare.flt`
+            List of filters.
+        """
         keywords = ["FILTER_REP", "FILTER_LIST", "TRANS_TYPE", "FILTER_CALIB", "FILTER_FILE"]
         keymap = {}
         with open(config_file) as fstream:
@@ -72,17 +101,69 @@ class FilterSvc:
 
     @classmethod
     def from_svo(cls, counter, filter_id, system="AB", calib=0):
+        """Return filter from SVO
+
+        Parameters
+        ----------
+        counter : `int`
+            Filter number
+        filter_id : `str`
+            Id of filter in SVO format.
+        system : `str`, optional
+            Photometric system
+        calib : `float`, optional
+            Calibration value. Not currently used.
+
+        Returns
+        -------
+        res : `lephare.flt`
+            Filter in native lephare format.
+        """
         res = FilterSvc.svo_request(counter, filter_id, system)
         return res
 
     @classmethod
     def from_file(cls, filename, counter=-1, trans=0, calib=0):
+        """Return filter from SVO
+
+        Parameters
+        ----------
+        filename : `str`
+            Path to filter file.
+        counter : `int`
+            Filter number
+        trans : `int`, optional
+            Photometric system.
+        calib : `int`, optional
+            Calibration value.
+
+        Returns
+        -------
+        f : `lephare.flt`
+            Filter in native lephare format.
+        """
         name = filename.replace("$LEPHAREDIR", LEPHAREDIR)
         f = flt(counter, name, trans, calib)
         return f
 
     @classmethod
     def svo_request(cls, counter, filter_id, system):
+        """Retrieve a filter from the SVO
+
+        Parameters
+        ----------
+        counter : `int`
+            Filter number
+        filter_id : `str`
+            Id of filter in SVO format.
+        system : `str`, optional
+            Photometric system
+
+        Returns
+        -------
+        res : `lephare.flt`
+            Filter in native lephare format.
+        """
         try:
             query = f"{SVO_URL}/fps.php?PhotCalID={filter_id}/{system}"
             r = requests.get(query)

--- a/src/lephare/magSvc.py
+++ b/src/lephare/magSvc.py
@@ -8,8 +8,20 @@ __all__ = [
 
 
 class MagSvc:
+    """Magnitude service to return magnitudes of a single SED."""
+
     @classmethod
     def from_config(cls, objtype, config_file):
+        """Load config and return magnitudes
+
+        Parameters
+        ----------
+        objtype : `str`
+            The type of object galaxy, star, or qso based on case insensitive first
+            letter of string.
+        config_file : `str`
+            Path to config file.
+        """
         keywords = [
             "COSMOLOGY",
             "FILTER_FILE",

--- a/src/lephare/mag_gal.py
+++ b/src/lephare/mag_gal.py
@@ -29,10 +29,28 @@ mag_gal_config_keys = [
 
 
 class MagGal(Runner):
+    """Use the galaxy templates and filters to derive a library of predicted magnitudes.
+
+    The run method of this class is equivalent to the mag_gal command line.
+
+    Parameters
+    ----------
+    config_file : `string` or `None`, optional
+        Path to config file in LePHARE .para format
+    config_keymap : `dict` or `None`, optional
+        Dictionary of all config values as alternative to config file.
+    """
+
     def __init__(self, config_file=None, config_keymap=None):
         super().__init__(mag_gal_config_keys, config_file, config_keymap)
 
     def run(self, **kwargs):
+        """Compute the model magnitudes across the redshift grid.
+
+        Returns
+        -------
+        None
+        """
         # update keymap and verbosity based on call arguments
         # this is only when the code is called from python session
         self.verbose = kwargs.pop("verbose", self.verbose)

--- a/src/lephare/runner.py
+++ b/src/lephare/runner.py
@@ -6,6 +6,18 @@ from lephare._lephare import get_lephare_env, keyword
 
 
 class Runner:
+    """Base class holding config values for running all stages.
+
+    Parameters
+    ----------
+    config_keys : `list` or `None`, optional
+        List of all config keys
+    config_file : `string` or `None`, optional
+        Path to config file in LePHARE .para format
+    config_keymap : `dict` or `None`, optional
+        Dictionary of all config values as alternative to config file.
+    """
+
     def __init__(self, config_keys=None, config_file=None, config_keymap=None):
         # set the LEPHAREDIR and LEPHAREWORK env variable
         get_lephare_env()
@@ -37,6 +49,13 @@ class Runner:
 
     # This function take the config file, read it line per linem and output a keyword map
     def parse_config_file(self, filename):
+        """Load config file and set config values.
+
+        Parameters
+        ----------
+        filename : `string`
+            Path to config file
+        """
         if not os.path.exists(filename):
             raise RuntimeError("File %s not found" % filename)
         self.config = filename
@@ -67,6 +86,13 @@ class Runner:
         self.keymap = keymap
 
     def config_parser(self, config_keys):
+        """Create command line config parser from list of keys
+
+        Parameters
+        ----------
+        config_keys : `list`
+            List of all config keys
+        """
         parser = argparse.ArgumentParser(add_help=False)
         # No required positional argument as in the C++ code, though in there
         # absence of the config file results in exiting. Need to understand whether

--- a/src/lephare/sedtolib.py
+++ b/src/lephare/sedtolib.py
@@ -25,12 +25,29 @@ sedtolib_config_keys = [
 
 
 class Sedtolib(Runner):
+    """Read a configurable set of SED, compute extinction corrections, and store the
+    results into a binary library for later use.
+
+    The run method is equivalent to the terminal sedtolib command.
+
+    Parameters
+    ----------
+    config_file : `string` or `None`, optional
+        Path to config file in LePHARE .para format
+    config_keymap : `dict` or `None`, optional
+        Dictionary of all config values as alternative to config file.
+    """
+
     # Initalisation
     def __init__(self, config_file=None, config_keymap=None):
         # Class heritates from runner. So, __init__ in runner.py
         super().__init__(sedtolib_config_keys, config_file, config_keymap)
 
     def run(self, **kwargs):
+        """Take keymap and set SED library as class variable.
+
+        Must be run independently for stars, galaxies, and QSO.
+        """
         # update keymap and verbosity based on call arguments
         # this is only when the code is called from python session
         self.verbose = kwargs.pop("verbose", self.verbose)

--- a/src/lephare/zphota.py
+++ b/src/lephare/zphota.py
@@ -77,6 +77,17 @@ nonestring = "NONE"
 
 
 class Zphota(Runner):
+    """Performs chisquare minimization in order to derive photometric redshifts and
+    other physical parameters.
+
+    Equivalent to zphota command.
+
+    Parameters
+    ----------
+    config_file : `str`
+        Path to config file.
+    """
+
     def __init__(self, config_file=None):
         super().__init__(zphota_config_keys, config_file)
 


### PR DESCRIPTION
I started some basic docstrings for the public Python classes and functions. This is in response to Issue 38:

https://github.com/lincc-frameworks/lephare-dev/issues/38

Private classes and bound classes still don't have docstrings.

Please let me know if I am not conducting the issue creation or pull request correctly :)

- [ x] My PR includes a link to the issue that I am addressing

## Code Quality
- [x ] I have read the Contribution Guide
- [x ] My code follows the code style of this project
- [x ] My code builds (or compiles) cleanly without any errors or warnings
- [ x] My code contains relevant comments and necessary documentation

### Documentation Change Checklist
- [ x] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Other Change Checklist
- [ x] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
