### PR TITLE
Small updates to notebooks for new repo/directory structure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,15 +17,15 @@ repos:
       name: clang-format
       types_or: [c++, c]
     # Clear output from jupyter notebooks so that only the input cells are committed.
-  - repo: local
-    hooks:
-      - id: jupyter-nb-clear-output
-        name: Clear output from Jupyter notebooks
-        description: Clear output from Jupyter notebooks.
-        files: \.ipynb$
-        stages: [commit]
-        language: system
-        entry: jupyter nbconvert --clear-output
+  # - repo: local
+  #   hooks:
+  #     - id: jupyter-nb-clear-output
+  #       name: Clear output from Jupyter notebooks
+  #       description: Clear output from Jupyter notebooks.
+  #       files: \.ipynb$
+  #       stages: [commit]
+  #       language: system
+  #       entry: jupyter nbconvert --clear-output
     # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,15 +17,15 @@ repos:
       name: clang-format
       types_or: [c++, c]
     # Clear output from jupyter notebooks so that only the input cells are committed.
-  # - repo: local
-  #   hooks:
-  #     - id: jupyter-nb-clear-output
-  #       name: Clear output from Jupyter notebooks
-  #       description: Clear output from Jupyter notebooks.
-  #       files: \.ipynb$
-  #       stages: [commit]
-  #       language: system
-  #       entry: jupyter nbconvert --clear-output
+  - repo: local
+    hooks:
+      - id: jupyter-nb-clear-output
+        name: Clear output from Jupyter notebooks
+        description: Clear output from Jupyter notebooks.
+        files: \.ipynb$
+        stages: [commit]
+        language: system
+        entry: jupyter nbconvert --clear-output
     # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/docs/notebooks/Example_of_usage_of_magSvc.ipynb
+++ b/docs/notebooks/Example_of_usage_of_magSvc.ipynb
@@ -2,7 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "35bfb94a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"LEPHAREDIR\"] = os.path.abspath(\"../..\")\n",
+    "os.environ[\"LEPHAREWORK\"] = \"../../examples/WORK\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ebb9f0ee",
    "metadata": {},
    "outputs": [],
@@ -18,28 +31,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e29423bc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "allFlt = FilterSvc.from_config(\"../examples/COSMOS.para\")"
+    "allFlt = FilterSvc.from_config(\"../../examples/COSMOS.para\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "046b4781",
    "metadata": {},
    "outputs": [],
    "source": [
     "sed = StarSED(\"test\", 0)\n",
-    "sed.read(\"../sed/STAR/BD_NEW/lte012.0-4.0-0.0a+0.0.BT-Settl.spec.txt\")"
+    "sed.read(\"../../sed/STAR/BD_NEW/lte012.0-4.0-0.0a+0.0.BT-Settl.spec.txt\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "3056c57c",
    "metadata": {},
    "outputs": [],
@@ -49,25 +62,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "fe5e0190",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of keywords read in the config file: 92\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "mag = MagSvc.from_config(\"Star\", \"../examples/COSMOS.para\")"
+    "mag = MagSvc.from_config(\"Star\", \"../../examples/COSMOS.para\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "bce7a3d2",
    "metadata": {},
    "outputs": [],
@@ -82,8 +87,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "newsed.mag"
+    "newsed[0].mag"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf5a467c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -102,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/intro.ipynb
+++ b/docs/notebooks/intro.ipynb
@@ -21,6 +21,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eebc75ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"LEPHAREDIR\"] = os.path.abspath(\"../..\")\n",
+    "os.environ[\"LEPHAREWORK\"] = \"WORK\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "93246777",
    "metadata": {},
@@ -81,6 +94,14 @@
     "# (1+z) binning\n",
     "redshifts2 = zgrid(1, 0.01, 0, 6)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd6c7698",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -99,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
After importing the required data files (and using the same directory structure of the original gitlab repo) I was able to run this notebook after making only one small adjustment. 

I would recommend that we take the approach outlined in the first cell of this notebook for all the remaining notebooks as well, namely: 
```
import os

os.environ["LEPHAREDIR"] = os.path.abspath("../..")
os.environ["LEPHAREWORK"] = "WORK"
```