### PR TITLE
Issue/46/fix float vs double issue in globals

### DIFF
--- a/src/lib/globals.h
+++ b/src/lib/globals.h
@@ -55,14 +55,14 @@ inline double POW10DSLOW(double x) { return pow(10.0, x); }
 inline double log2f_approx(double X) {
   double Y, F;
   int E;
-  F = frexpf(fabsf(X), &E);
-  Y = 1.23149591368684f;
+  F = frexp(fabs(X), &E);
+  Y = 1.23149591368684;
   Y *= F;
-  Y += -4.11852516267426f;
+  Y += -4.11852516267426;
   Y *= F;
-  Y += 6.02197014179219f;
+  Y += 6.02197014179219;
   Y *= F;
-  Y += -3.13396450166353f;
+  Y += -3.13396450166353;
   Y += E;
   return (Y);
 }


### PR DESCRIPTION
Simple fix to remove warnings on mac builds caused by mixing of floats and doubles. Relates to issue 46:

issue/46/fix-float-vs-double-issue-in-globals

## Change Description
Floats and float functions replaced with doubles.


- [x] My PR includes a link to the issue that I am addressing



## Solution Description
Remove the trailing letter f to turn floats to doubles.



## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
