### PR TITLE
Set default environment variables if they are not set

### DIFF
--- a/src/lephare/__init__.py
+++ b/src/lephare/__init__.py
@@ -1,25 +1,68 @@
 # ruff: noqa: E402
 # ruff: noqa: F403
 
+import datetime
+import logging
 import os
 
+# Why is this global?
 global LEPHAREDIR
+# Get the default cache location
+if os.name == "nt":
+    this_os_cache = os.getenv("LOCALAPPDATA")
+else:
+    this_os_cache = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/Library/Caches"))
 
-try:
-    LEPHAREDIR = os.environ["LEPHAREDIR"]
-except KeyError:
-    raise RuntimeError("Environment variable LEPHAREDIR has not been set")  # noqa: B904
+# Check if user defined environment variables present
+LEPHAREDIR = os.environ.get("LEPHAREDIR", None)
+# If not set set to default and make directories if not present
+if LEPHAREDIR is None:
+    # Default location in system cache
+    LEPHAREDIR = this_os_cache + "/lephare/data"
+    # Set environment variable to default
+    os.environ["LEPHAREDIR"] = LEPHAREDIR
+    if os.path.isdir(LEPHAREDIR):
+        pass
+    else:
+        logging.warning(
+            f"""Lephare default cache directory being created at
+            {LEPHAREDIR}. More than 1Gb may be written there."""
+        )
+        os.mkdir(LEPHAREDIR)
+else:
+    logging.warning(
+        f"""User defined LEPHAREDIR is set. Code runs depend on all required
+        auxilliary data being present at {LEPHAREDIR}."""
+    )
 
-try:
-    os.mkdir(os.environ["LEPHAREWORK"])
-    os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "filt"))
-    os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "lib_bin"))
-    os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "lib_mag"))
-    os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "zphota"))
-except FileExistsError:
-    pass
-except KeyError:
-    raise RuntimeError("Environment variable LEPHAREWORK has not been set")  # noqa: B904
+LEPHAREWORK = os.environ.get("LEPHAREWORK", None)
+# If not set thenset to default and make directories if not present
+if LEPHAREWORK is None:
+    # Default location in system cache
+    LEPHAREWORK = this_os_cache + "/lephare/work"
+    # Set environment variable to default
+    os.environ["LEPHAREWORK"] = LEPHAREWORK
+    if os.path.isdir(LEPHAREWORK):
+        pass
+    else:
+        # Make a timestamped 'run' directory which is symlinked from default
+        now = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+        RUNDIR = f"{LEPHAREWORK}/runs/{now}"
+        logging.warning(
+            f"""Lephare default working directory being created at
+            {LEPHAREWORK}."""
+        )
+        os.mkdir(RUNDIR)
+        os.symlink(RUNDIR, LEPHAREWORK)
+        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "filt"))
+        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "lib_bin"))
+        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "lib_mag"))
+        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "zphota"))
+else:
+    logging.warning(
+        f"""User defined LEPHAREWORK is set. All intermediate files will
+         be written to {LEPHAREWORK}."""
+    )
 
 
 from ._lephare import *
@@ -32,6 +75,7 @@ from ._flt import *
 from ._pdf import *
 from ._photoz import *
 from ._spec import *
+from ._version import *
 from .filter import *
 from .filterSvc import *
 from .mag_gal import *

--- a/src/lephare/__init__.py
+++ b/src/lephare/__init__.py
@@ -2,7 +2,6 @@
 # ruff: noqa: F403
 
 import datetime
-import logging
 import os
 
 # Why is this global?
@@ -24,13 +23,13 @@ if LEPHAREDIR is None:
     if os.path.isdir(LEPHAREDIR):
         pass
     else:
-        logging.warning(
+        print(
             f"""Lephare default cache directory being created at
             {LEPHAREDIR}. More than 1Gb may be written there."""
         )
-        os.mkdir(LEPHAREDIR)
+        os.makedirs(LEPHAREDIR)
 else:
-    logging.warning(
+    print(
         f"""User defined LEPHAREDIR is set. Code runs depend on all required
         auxilliary data being present at {LEPHAREDIR}."""
     )
@@ -43,23 +42,26 @@ if LEPHAREWORK is None:
     # Set environment variable to default
     os.environ["LEPHAREWORK"] = LEPHAREWORK
     if os.path.isdir(LEPHAREWORK):
-        pass
+        print(
+            f"""Lephare default working directory already exists at
+            {LEPHAREWORK}."""
+        )
     else:
         # Make a timestamped 'run' directory which is symlinked from default
         now = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
-        RUNDIR = f"{LEPHAREWORK}/runs/{now}"
-        logging.warning(
+        RUNDIR = f"{this_os_cache}/lephare/runs/{now}"
+        print(
             f"""Lephare default working directory being created at
             {LEPHAREWORK}."""
         )
-        os.mkdir(RUNDIR)
+        os.makedirs(RUNDIR)
         os.symlink(RUNDIR, LEPHAREWORK)
-        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "filt"))
-        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "lib_bin"))
-        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "lib_mag"))
-        os.mkdir(os.path.join(os.environ["LEPHAREWORK"], "zphota"))
+        os.makedirs(os.path.join(os.environ["LEPHAREWORK"], "filt"))
+        os.makedirs(os.path.join(os.environ["LEPHAREWORK"], "lib_bin"))
+        os.makedirs(os.path.join(os.environ["LEPHAREWORK"], "lib_mag"))
+        os.makedirs(os.path.join(os.environ["LEPHAREWORK"], "zphota"))
 else:
-    logging.warning(
+    print(
         f"""User defined LEPHAREWORK is set. All intermediate files will
          be written to {LEPHAREWORK}."""
     )


### PR DESCRIPTION
We have tried to implement a simple solution which can still take user defined environment variables but otherwise will create a new directory in the cache for storing both auxiliary files and intermediate outputs. Both can be overwritten if required but this should now allow making notebooks that will run on a freshly installed lephare environment

This PR relates to issue/32/environment-variables-defaults

The code that runs in __init__.py should be perhaps moved to a distinct file.

- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
